### PR TITLE
Fix: Enable Checkbox prevents CPR when disabled

### DIFF
--- a/adv_aceCPR/functions/fn_CPR_action.sqf
+++ b/adv_aceCPR/functions/fn_CPR_action.sqf
@@ -28,8 +28,11 @@ if ( _enable ) exitWith {
 	true;
 };
 
+//Calls normal ace function for a completed round of CPR 
+[_caller, _target] call ace_medical_treatment_fnc_cprSuccess;
+
 //diagnostics:
-[_target, "CPR action is not being executed"] call adv_aceCPR_fnc_diag;
+[_target, "Custom CPR action is not being executed"] call adv_aceCPR_fnc_diag;
 
 //return:
 false;


### PR DESCRIPTION
If the checkbox is disabled, default Ace CPR doesn't correctly complete, due to the redirection of function flow in the config. This fix allows for CPRSuccess function to run, which will then run the CPRLocal function on the target to check if the round of CPR will bring the patient out of cardiac arrest.

Steps to reproduce issue this fixes:
Turn off the enable ADV CPR checkbox.
Perform CPR on a patient.
Ensure patient remains in cardiac arrest (or put them back into cardiac arrest afterwards).

Subsequent rounds of CPR will not be possible as the "ace_medical_CPR_provider" variable is not set back to objNull