### PR TITLE
Modification: Improve inRevive Logic

### DIFF
--- a/adv_aceCPR/functions/fn_isResurrectable.sqf
+++ b/adv_aceCPR/functions/fn_isResurrectable.sqf
@@ -1,6 +1,9 @@
 /*
 ADV_aceCPR_fnc_canCPR - by Belbo
+
+Determines if CPR is 
 */
+
 
 params [
 	["_target", objNull, [objNull]]
@@ -9,10 +12,22 @@ params [
 private _inRevive = _target call adv_aceCPR_fnc_inReviveState;
 private _inCardiac = _target getVariable ["ace_medical_inCardiacArrest",false];
 
-if !(alive _target && (_inRevive || _inCardiac)) exitWith { true };
-if (!_inRevive && _inCardiac) exitWith { true };
+//rewritten to make the use cases easily distinguishable
+//Dead (kept to keep same functionality as old code. was this intentional?)
+if (!alive _target) exitWith { true };
 
-private _startTime = _target getVariable ["adv_aceCPR_cardiacArrestStart", CBA_missionTime];
-private _cprMaxTime = missionNamespace getVariable ["adv_aceCPR_maxTime", 900];
+//Alive and unconscious but not in cardiac (no cardiac reference as the states are mutually exclusive)
+if (alive _target && _inRevive) exitWith { true };
 
-CBA_missionTime < _startTime + _cprMaxTime
+//In cardiac 
+if (_inCardiac) exitWith {
+	private _startTime = _target getVariable ["adv_aceCPR_cardiacArrestStart", CBA_missionTime];
+	private _cprMaxTime = missionNamespace getVariable ["adv_aceCPR_maxTime", 900];
+
+	CBA_missionTime < _startTime + _cprMaxTime;
+};
+
+// if awake
+false
+//end rewrite
+

--- a/adv_aceCPR/functions/fn_isResurrectable.sqf
+++ b/adv_aceCPR/functions/fn_isResurrectable.sqf
@@ -1,7 +1,7 @@
 /*
 ADV_aceCPR_fnc_canCPR - by Belbo
 
-Determines if CPR is 
+Determines if CPR has the ability to be successful
 */
 
 
@@ -13,10 +13,10 @@ private _inRevive = _target call adv_aceCPR_fnc_inReviveState;
 private _inCardiac = _target getVariable ["ace_medical_inCardiacArrest",false];
 
 //rewritten to make the use cases easily distinguishable
-//Dead (kept to keep same functionality as old code. was this intentional?)
-if (!alive _target) exitWith { true };
+//Dead 
+if (!alive _target) exitWith { false };
 
-//Alive and unconscious but not in cardiac (no cardiac reference as the states are mutually exclusive)
+//Alive and unconscious but not in cardiac (cardiac and unconscious are mutually exclusive)
 if (alive _target && _inRevive) exitWith { true };
 
 //In cardiac 
@@ -28,6 +28,5 @@ if (_inCardiac) exitWith {
 };
 
 // if awake
-false
-//end rewrite
+true
 


### PR DESCRIPTION
This pull request changes the inRevive logic to make the code easier to understand, and to make the outputs in the activity log line up with the state of the patient.

CPR outputs should reflect normal CPR cycles, except when the patient has passed the max cardiac time setting, or when they are dead.

This also fixes a bug where the max CPR time setting is never reached, as if (!_inRevive && _inCardiac) exitWith { true }; will always return true while in cardiac arrest.