### PR TITLE
Fix: Bandaged and Cleared Wounds Affect CPR probability

### DIFF
--- a/adv_aceCPR/functions/fn_getBloodLoss.sqf
+++ b/adv_aceCPR/functions/fn_getBloodLoss.sqf
@@ -4,11 +4,9 @@ ADV_aceCPR_fnc_getBloodLoss - by Belbo
 
 params ["_caller", "_target"];
 
-//count the total blood loss amounting from every wound the player has:
-private _totalBloodLoss = 0;
-{
-    _totalBloodLoss = _totalBloodLoss + ((_x select 4) * (_x select 3));
-} forEach (_target getVariable ["ace_medical_openWounds", []]);
+//Blood loss of all unbandaged, untourniquetted wounds
+private _totalBloodLoss = (_target getVariable ["ace_medical_woundBleeding", 0]);
+
 
 //diagnostics:
 [_caller,format ["the patient has a bloodloss of %1",_totalBloodLoss]] call adv_aceCPR_fnc_diag;


### PR DESCRIPTION
This pull request fixes an issue where damage from the wounds, and tourniqueted wounds negatively affect CPR probability. The issue is caused by the selection of damage and bleed rate from the wound array rather than amount and bleed rate. This fix should make it so that only wounds that are actively bleeding (unbandaged, non tourniqueted) wounds to count towards the probability reduction

If the intention is for tourniqueted wounds to affect CPR probabilities, an alternative would be to change the two selections from 3 and 4 to 2 and 3. 